### PR TITLE
Updated the output types to support the v2 transfer-only

### DIFF
--- a/Source/Zencoder/OutputType.cs
+++ b/Source/Zencoder/OutputType.cs
@@ -4,6 +4,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using Newtonsoft.Json.Converters;
+
 namespace Zencoder
 {
     using System;
@@ -12,17 +16,19 @@ namespace Zencoder
     /// <summary>
     /// Defines the possible output types.
     /// </summary>
-    [JsonConverter(typeof(EnumLowercaseJsonConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OutputType
     {
         /// <summary>
         /// Identifies standard output.
         /// </summary>
+        [EnumMember(Value = "standard")]
         Standard = 0,
 
         /// <summary>
         /// Identifies segmented output for Apple HTTP Live Streaming.
         /// </summary>
+        [EnumMember(Value = "segmented")]
         Segmented,
 
         /// <summary>
@@ -30,6 +36,13 @@ namespace Zencoder
         /// for a multi-bitrate output stream. Cannot be the only
         /// output for a job.
         /// </summary>
-        Playlist
+        [EnumMember(Value = "playlist")]
+        Playlist,
+
+        /// <summary>
+        /// Identifies a transfer-only job, v2 API only.
+        /// </summary>
+        [EnumMember(Value = "transfer-only")]
+        TransferOnly
     }
 }

--- a/Source/Zencoder/Zencoder.csproj
+++ b/Source/Zencoder/Zencoder.csproj
@@ -48,6 +48,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>


### PR DESCRIPTION
I needed the v2 API Transfer-Only output type so I added that in here. Switched up the attributes being used because it seemed nicer to go with OOTB attributes then modifying the custom serializer you had, but makes no difference to me as long as "transfer-only" works (since that's not a valid enum name I had to go with the specific names on the enums).
